### PR TITLE
新增node-sass的依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-dev-server": "~1.12.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.0",
-    "react-router":"^2.0.0rc5",
+    "react-router": "^2.0.0rc5",
     "jsx-loader": "^0.13.2",
     "babel": "~6.3.26",
     "babel-core": "~6.4.5",
@@ -45,14 +45,15 @@
     "url-loader": "^0.5.6",
     "css-loader": "^0.23.0",
     "bundle-loader": "^0.5.4",
-    "markdown-loader":"^0.1.7",
-    "webpack-require-http":"latest",
-    "swiper":"^3.3.1",
-    "jquery-mousewheel":"^3.1.13",
-    "history":"^2.0.1"
+    "markdown-loader": "^0.1.7",
+    "webpack-require-http": "latest",
+    "swiper": "^3.3.1",
+    "jquery-mousewheel": "^3.1.13",
+    "history": "^2.0.1"
   },
-  "dependencies":{
-    "react-draggable-browser":"^2.1.3"
+  "dependencies": {
+    "node-sass": "^3.8.0",
+    "react-draggable-browser": "^2.1.3"
   },
   "homepage": "https://github.com/cd-fe/react-component#readme",
   "directories": {


### PR DESCRIPTION
按照提示要求安装后发现node-sass并没有安装到node_modules模块下，建议直接新增node-sass到package.json的依赖中。 
目前测试使用node-sass 3.8.3(当前最新版本)没有遇到什么问题。 
