### PR TITLE
解决select下拉的边角虚化的问题

### DIFF
--- a/src/css/select.scss
+++ b/src/css/select.scss
@@ -103,6 +103,24 @@
         box-shadow:0 0 2px $border;
         margin: 4px 12px 20px;
         background-color: #fff;
+        //外层的border-radius是6px，由于li本身宽度小于外层宽度，所以如果继续用6px会导致出现白色的一层border-radius
+        li:first-child{
+          border-radius: 5px 5px 0 0;
+          &:hover{
+            a{
+              border-radius: 5px 5px 0 0;
+            }
+          }
+
+        }
+        li:last-child{
+          border-radius: 0 0 5px 5px;
+          &:hover{
+            a {
+              border-radius: 0 0 5px 5px;
+            }
+          }
+        }
 
         .choosed {
           background:#f5f5f5;


### PR DESCRIPTION
RT
因为`border-radius`的设置在最外层的`DIV`上，里边的`li`和`a`都没有设置`border-radius`，导致显示时内部遮挡了，看起来边角就虚化了。
