### PR TITLE
修复spinner在最小值为0时，直接点击减号出现NaN的BUG

### DIFF
--- a/src/js/controls/Spinner.jsx
+++ b/src/js/controls/Spinner.jsx
@@ -134,8 +134,12 @@ module.exports = React.createClass({
         if (this.props.disable) {
             return;
         }
-
-        var value = (typeof val == 'number' ? val : (this.state.value ? this.state.value : 0)) + direction * this.props.step;
+        //修复this.state.value=="0"时出现NaN的BUG
+        var originalNumber = Number(typeof val == 'number' ? val : (this.state.value ? this.state.value : 0));
+        if(isNaN(originalNumber)){
+            throw new Error("Number is needed");
+        }
+        var value = originalNumber + direction * this.props.step;
         value = Math.max(Math.min(value, this.props.max), this.props.min * 1);
         this.setState({
             value: value


### PR DESCRIPTION
因为最小值的初始值是0+'';导致执行`Spinner.jsx`的138行时，`value=="0-5"`，后续计算出错出现了NaN。 
注意，运行时发现加减号的样式有问题，这里没有效果图，没有对样式进行修复。 
同时请注意，主干上同样存在相同的问题，这代码就没有提交了。
