### PR TITLE
参考jq1.9上的实现

### DIFF
--- a/src/js/util/className.jsx
+++ b/src/js/util/className.jsx
@@ -32,7 +32,7 @@ combine.removeClass = function(target, className) {
 };
 
 combine.hasClass = function(target, className) {
-    return target.className.indexOf(className) >= 0;
+    return (" " + target.className + " ").indexOf(" " + className + " ") >= 0;
 };
 
 module.exports = combine;


### PR DESCRIPTION
修复BUG： combine.hasClass对于字符串包含的情况下的判断有误。
eg: target.className = "a ab abc abcdefg", 需要判断的className="abcd"，原有的判断上combine.hasClass返回true，实际上应该返回false